### PR TITLE
Use grep(1) instead of sed(1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Q. **I don't want to use rofi !**
 
 A. You can also use greenclip with [dmenu](http://tools.suckless.org/dmenu) or [fzf](https://github.com/junegunn/fzf). Example usage:
 
-   `greenclip print | sed '/^$/d' | dmenu -i -l 10 -p clipboard | xargs -r -d'\n' -I '{}' greenclip print '{}'`
+   `greenclip print | grep . | dmenu -i -l 10 -p clipboard | xargs -r -d'\n' -I '{}' greenclip print '{}'`
 
-   `greenclip print | sed '/^$/d' | fzf -e | xargs -r -d'\n' -I '{}' greenclip print '{}'`
+   `greenclip print | grep . | fzf -e | xargs -r -d'\n' -I '{}' greenclip print '{}'`
 
 ----------
 


### PR DESCRIPTION
`grep .` and `sed '/^$/d'` perform the exact same task, but `grep` does
it faster. Since these commands are going to probably end up in peoples
scripts, they should be given the fastest alternative.
