### PR TITLE
stack: Update to lts-20.0

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-16.31
+resolver: lts-20.0
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -43,7 +43,9 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - 'wordexp-0.2.2'
-- 'protolude-0.3.0'
+- 'protolude-0.3.2'
+- 'tomland-1.3.3.2'
+- 'validation-selective-0.1.0.2'
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
While [updating](https://github.com/void-linux/void-packages/pull/41316) Void to GHC 9.2.5, I noticed some build failures for greenclip.  The project itself builds fine on GHC 9.2.5, it's just that the stack.yaml file needs a few adjustments.

We could of course maintain our own stack.yaml, but I figured since tracking stackage LTS is a good idea anyways, this may well be upstreamed.  Feel free to ignore if there's a specific reason the resolver is still on 16.31.