### PR TITLE
Add prune command to clear sensitive entries

### DIFF
--- a/greenclip.cabal
+++ b/greenclip.cabal
@@ -40,6 +40,8 @@ executable greenclip
     , directory
     , wordexp
     , tomland
+    , base16-bytestring
+    , cryptohash-md5
     , X11 >= 1.6
   other-modules:
       Clipboard


### PR DESCRIPTION
This adds a mechanism to sanitize entries such as passwords, which often accumulate if one uses a password manager.

To use, first create a file with each password's MD5 hash (one per line). If one uses bitwarden, something like this should work:

```
bw list items | \
    jq -r 'map(.login.password) | del(..|nulls) | unique | join("\n")' | \
    while read i; do echo -n "$i" | md5sum | cut -f1 -d' '; done \
    > path/to/hashes
```

Then run:

```
greenclip prune <path/to/hashes>
```

This may also need the pkill chain from the FAQ, but it seems to work without.

Super simple and doesn't break anything ;)